### PR TITLE
Image features

### DIFF
--- a/ocrd_calamari/recognize.py
+++ b/ocrd_calamari/recognize.py
@@ -48,10 +48,10 @@ class CalamariRecognize(Processor):
         checkpoints = glob(self.parameter['checkpoint'])
         self.predictor = MultiPredictor(checkpoints=checkpoints)
 
-        self.input_channels = self.predictor.predictors[0].network.input_channels
-        #self.input_channels = self.predictor.predictors[0].network_params.channels # not used!
+        self.network_input_channels = self.predictor.predictors[0].network.input_channels
+        #self.network_input_channels = self.predictor.predictors[0].network_params.channels # not used!
         # binarization = self.predictor.predictors[0].model_params.data_preprocessor.binarization # not used!
-        # self.features = ('' if self.input_channels != 1 else
+        # self.features = ('' if self.network_input_channels != 1 else
         #                  'binarized' if binarization != 'GRAY' else
         #                  'grayscale_normalized')
         self.features = ''
@@ -91,7 +91,7 @@ class CalamariRecognize(Processor):
                     log.debug("Recognizing line '%s' in region '%s'", line.id, region.id)
 
                     line_image, line_coords = self.workspace.image_from_segment(line, region_image, region_coords, feature_selector=self.features)
-                    if ('binarized' not in line_coords['features'] and 'grayscale_normalized' not in line_coords['features'] and self.input_channels == 1):
+                    if ('binarized' not in line_coords['features'] and 'grayscale_normalized' not in line_coords['features'] and self.network_input_channels == 1):
                         # We cannot use a feature selector for this since we don't
                         # know whether the model expects (has been trained on)
                         # binarized or grayscale images; but raw images are likely

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -10,6 +10,7 @@ from ocrd_calamari import CalamariRecognize
 from .base import assets
 
 METS_KANT = assets.url_of('kant_aufklaerung_1784-page-block-line-word_glyph/data/mets.xml')
+CHECKPOINT = os.path.join(os.getcwd(), 'gt4histocr-calamari/*.ckpt.json')
 WORKSPACE_DIR = '/tmp/test-ocrd-calamari'
 
 
@@ -52,9 +53,7 @@ def test_recognize(workspace):
         workspace,
         input_file_grp="OCR-D-GT-SEG-LINE",
         output_file_grp="OCR-D-OCR-CALAMARI",
-        parameter={
-            'checkpoint': os.path.join(os.getcwd(), 'gt4histocr-calamari/*.ckpt.json')
-        }
+        parameter={'checkpoint': CHECKPOINT}
     ).process()
     workspace.save_mets()
 

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -95,8 +95,8 @@ def test_recognize_with_checkpoint_dir(workspace):
 
     page1 = os.path.join(workspace.directory, "OCR-D-OCR-CALAMARI/OCR-D-OCR-CALAMARI_0001.xml")
     assert os.path.exists(page1)
-    with open(page1, 'r', encoding='utf-8') as f:
-        assert 'verſchuldeten' in f.read()
+    with open(page1, "r", encoding="utf-8") as f:
+        assert "verſchuldeten" in f.read()
 
 
 def test_recognize_should_warn_if_given_rgb_image_and_single_channel_model(workspace, caplog):
@@ -110,8 +110,6 @@ def test_recognize_should_warn_if_given_rgb_image_and_single_channel_model(works
 
     interesting_log_messages = [t[2] for t in caplog.record_tuples if "Using raw image" in t[2]]
     assert len(interesting_log_messages) > 10  # For every line!
-    with open(page1, "r", encoding="utf-8") as f:
-        assert "verſchuldeten" in f.read()
 
 
 def test_word_segmentation(workspace):

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -4,6 +4,7 @@ import subprocess
 import urllib.request
 
 import pytest
+import logging
 from ocrd.resolver import Resolver
 
 from ocrd_calamari import CalamariRecognize
@@ -61,3 +62,16 @@ def test_recognize(workspace):
     assert os.path.exists(page1)
     with open(page1, 'r', encoding='utf-8') as f:
         assert 'verſchuldeten' in f.read()
+
+
+def test_recognize_should_warn_if_given_rgb_image_and_single_channel_model(workspace, caplog):
+    caplog.set_level(logging.WARNING)
+    CalamariRecognize(
+        workspace,
+        input_file_grp="OCR-D-GT-SEG-LINE",
+        output_file_grp="OCR-D-OCR-CALAMARI-BROKEN",
+        parameter={'checkpoint': CHECKPOINT}
+    ).process()
+
+    interesting_log_messages = [t[2] for t in caplog.record_tuples if "Using raw image" in t[2]]
+    assert len(interesting_log_messages) > 10  # For every line!


### PR DESCRIPTION
Note: as the commented code indicates, it seems impossible to actually detect whether a model/checkpoint was trained on binarized or grayscale-normalized images. So all we can do is look at the number of channels and warn if raw images are used for single-channel models.

Besides, I believe it was a bug that existing `Word` and `Glyph` annotation below the line level had not been deleted. (Related: #9)