### PR TITLE
Resolve resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ venv.bak/
 /actevedef_718448162*
 /repo
 /test/assets
+gt4histocr-calamari*

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Finally recognize the text using ocrd_calamari and the downloaded model:
 ocrd-calamari-recognize -p '{ "checkpoint": "../gt4histocr-calamari1/*.ckpt.json" }' -I OCR-D-SEG-LINE -O OCR-D-OCR-CALAMARI
 ```
 
+or
+
+```
+ocrd-calamari-recognize -P checkpoint_dir ../gt4histocr-calamari1 -I OCR-D-SEG-LINE -O OCR-D-OCR-CALAMARI
+```
+
+
 You may want to have a look at the [ocrd-tool.json](ocrd_calamari/ocrd-tool.json) descriptions
 for additional parameters and default values.
 

--- a/ocrd_calamari/ocrd-tool.json
+++ b/ocrd_calamari/ocrd-tool.json
@@ -20,7 +20,7 @@
       "parameters": {
         "checkpoint_dir": {
           "description": "The directory containing calamari model files (*.ckpt.json). Uses all checkpoints in that directory",
-          "type": "string", "format": "file", "cacheable": true
+          "type": "string", "format": "file", "cacheable": true, "default": "qurator-gt4histocr-1.0"
         },
         "checkpoint": {
           "description": "The calamari model files (*.ckpt.json)",

--- a/ocrd_calamari/ocrd-tool.json
+++ b/ocrd_calamari/ocrd-tool.json
@@ -18,6 +18,10 @@
         "OCR-D-OCR-CALAMARI"
       ],
       "parameters": {
+        "checkpoint_dir": {
+          "description": "The directory containing calamari model files (*.ckpt.json). Uses all checkpoints in that directory",
+          "type": "string", "format": "file", "cacheable": true
+        },
         "checkpoint": {
           "description": "The calamari model files (*.ckpt.json)",
           "type": "string", "format": "file", "cacheable": true

--- a/ocrd_calamari/recognize.py
+++ b/ocrd_calamari/recognize.py
@@ -40,6 +40,8 @@ class CalamariRecognize(Processor):
     def _init_calamari(self):
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = TF_CPP_MIN_LOG_LEVEL
 
+        if self.parameter['checkpoint_dir']:
+            self.parameter['checkpoint'] = '%s/*.ckpt.json' % self.parameter['checkpoint_dir']
         checkpoints = glob(self.parameter['checkpoint'])
         self.predictor = MultiPredictor(checkpoints=checkpoints)
 

--- a/ocrd_calamari/recognize.py
+++ b/ocrd_calamari/recognize.py
@@ -40,7 +40,7 @@ class CalamariRecognize(Processor):
     def _init_calamari(self):
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = TF_CPP_MIN_LOG_LEVEL
 
-        if self.parameter.get('checkpoint_dir', None):
+        if not self.parameter.get('checkpoint', None) and self.parameter.get('checkpoint_dir', None):
             resolved = self.resolve_resource(self.parameter['checkpoint_dir'])
             self.parameter['checkpoint'] = '%s/*.ckpt.json' % resolved
         checkpoints = glob(self.parameter['checkpoint'])

--- a/ocrd_calamari/recognize.py
+++ b/ocrd_calamari/recognize.py
@@ -5,6 +5,7 @@ import itertools
 from glob import glob
 
 import numpy as np
+from calamari_ocr import __version__ as calamari_version
 from calamari_ocr.ocr import MultiPredictor
 from calamari_ocr.ocr.voting import voter_from_proto
 from calamari_ocr.proto import VoterParams
@@ -33,7 +34,7 @@ class CalamariRecognize(Processor):
 
     def __init__(self, *args, **kwargs):
         kwargs['ocrd_tool'] = OCRD_TOOL['tools'][TOOL]
-        kwargs['version'] = OCRD_TOOL['version']
+        kwargs['version'] = '%s (calamari %s)' % (OCRD_TOOL['version'], calamari_version)
         super(CalamariRecognize, self).__init__(*args, **kwargs)
 
     def _init_calamari(self):

--- a/ocrd_calamari/recognize.py
+++ b/ocrd_calamari/recognize.py
@@ -41,7 +41,8 @@ class CalamariRecognize(Processor):
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = TF_CPP_MIN_LOG_LEVEL
 
         if self.parameter.get('checkpoint_dir', None):
-            self.parameter['checkpoint'] = '%s/*.ckpt.json' % self.parameter['checkpoint_dir']
+            resolved = self.resolve_resource(self.parameter['checkpoint_dir'])
+            self.parameter['checkpoint'] = '%s/*.ckpt.json' % resolved
         checkpoints = glob(self.parameter['checkpoint'])
         self.predictor = MultiPredictor(checkpoints=checkpoints)
 

--- a/ocrd_calamari/recognize.py
+++ b/ocrd_calamari/recognize.py
@@ -40,7 +40,7 @@ class CalamariRecognize(Processor):
     def _init_calamari(self):
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = TF_CPP_MIN_LOG_LEVEL
 
-        if self.parameter['checkpoint_dir']:
+        if self.parameter.get('checkpoint_dir', None):
             self.parameter['checkpoint'] = '%s/*.ckpt.json' % self.parameter['checkpoint_dir']
         checkpoints = glob(self.parameter['checkpoint'])
         self.predictor = MultiPredictor(checkpoints=checkpoints)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ tensorflow >= 2.3.0rc2
 calamari-ocr == 1.0.*
 setuptools >= 41.0.0  # tensorboard depends on this, but why do we get an error at runtime?
 click
-ocrd >= 2.13.0
+ocrd >= 2.22.0

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -14,8 +14,8 @@ from .base import assets
 
 METS_KANT = assets.url_of('kant_aufklaerung_1784-page-region-line-word_glyph/data/mets.xml')
 WORKSPACE_DIR = '/tmp/test-ocrd-calamari'
-CHECKPPOINT_DIR = os.path.join(os.getcwd(), 'gt4histocr-calamari1')
-CHECKPOINT = os.path.join(CHECKPPOINT_DIR, '*.ckpt.json')
+CHECKPOINT_DIR = os.path.join(os.getcwd(), 'gt4histocr-calamari1')
+CHECKPOINT = os.path.join(CHECKPOINT_DIR, '*.ckpt.json')
 
 # Because XML namespace versions are so much fun, we not only use one, we use TWO!
 NSMAP = { "pc": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" }
@@ -88,7 +88,7 @@ def test_recognize_with_checkpoint_dir(workspace):
         input_file_grp="OCR-D-GT-SEG-LINE",
         output_file_grp="OCR-D-OCR-CALAMARI",
         parameter={
-            "checkpoin_dir": CHECKPOINT_DIR,
+            "checkpoint_dir": CHECKPOINT_DIR,
         }
     ).process()
     workspace.save_mets()

--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -14,7 +14,8 @@ from .base import assets
 
 METS_KANT = assets.url_of('kant_aufklaerung_1784-page-region-line-word_glyph/data/mets.xml')
 WORKSPACE_DIR = '/tmp/test-ocrd-calamari'
-CHECKPOINT = os.path.join(os.getcwd(), 'gt4histocr-calamari1/*.ckpt.json')
+CHECKPPOINT_DIR = os.path.join(os.getcwd(), 'gt4histocr-calamari1')
+CHECKPOINT = os.path.join(CHECKPPOINT_DIR, '*.ckpt.json')
 
 # Because XML namespace versions are so much fun, we not only use one, we use TWO!
 NSMAP = { "pc": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" }
@@ -72,6 +73,22 @@ def test_recognize(workspace):
         output_file_grp="OCR-D-OCR-CALAMARI",
         parameter={
             "checkpoint": CHECKPOINT,
+        }
+    ).process()
+    workspace.save_mets()
+
+    page1 = os.path.join(workspace.directory, "OCR-D-OCR-CALAMARI/OCR-D-OCR-CALAMARI_0001.xml")
+    assert os.path.exists(page1)
+    with open(page1, "r", encoding="utf-8") as f:
+        assert "verſchuldeten" in f.read()
+
+def test_recognize_with_checkpoint_dir(workspace):
+    CalamariRecognize(
+        workspace,
+        input_file_grp="OCR-D-GT-SEG-LINE",
+        output_file_grp="OCR-D-OCR-CALAMARI",
+        parameter={
+            "checkpoin_dir": CHECKPOINT_DIR,
         }
     ).process()
     workspace.save_mets()


### PR DESCRIPTION
Proof-of-concept implementation for OCR-D/core#559. With this change, the value `VAL` for `checkpoint_dir` is resolved as the first existing match

* as-is
* `$WORKSPACE_DIR/ocrd-calamari-recognize/VAL`
* `$HOME/.cache/ocrd-calamari-recognize/VAL`
* `$HOME/.local/share/ocrd-calamari-recognize/VAL`
* `$HOME/.config/ocrd-calamari-recognize/VAL`

If not resolveable, try to treat `VAL` as the `name` or a `url` in the core-bundled list of resources. If found, download that model tarball and extract it to `$HOME/.cache/ocrd-calamari-recognize/VAL`

The default logic is equivalent to

```
ocrd resmgr download ocrd-calamari-recognize VAL
```