### PR TITLE
requirements: prevent TF 2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 h5py < 3  # XXX tensorflow 2.4.0rc3 requires h5py~=2.10.0, but you'll have h5py 3.1.0 which is incompatible.
-tensorflow >= 2.3.0rc2
+tensorflow >= 2.3.0rc2, < 2.5.0 # 2.5 depends on h5py ~= 3.1 (incompatible model files)
 calamari-ocr == 1.0.*
 setuptools >= 41.0.0  # tensorboard depends on this, but why do we get an error at runtime?
 click


### PR DESCRIPTION
Since Tensorflow 2.5 is out (well, kind of, it's most recent on PyPI, but there's no GH release yet), which depends on h5py 3.1, model loading won't work anymore (or depending on the order of installation there will at least be an unresolved conflict around h5py).