### PR TITLE
descend to all available TextRegions recursively

### DIFF
--- a/ocrd_calamari/recognize.py
+++ b/ocrd_calamari/recognize.py
@@ -85,7 +85,7 @@ class CalamariRecognize(Processor):
             page_image, page_coords, page_image_info = self.workspace.image_from_page(
                 page, page_id, feature_selector=self.features)
 
-            for region in page.get_TextRegion():
+            for region in page.get_AllRegions(classes=['Text']):
                 region_image, region_coords = self.workspace.image_from_segment(
                     region, page_image, page_coords, feature_selector=self.features)
 


### PR DESCRIPTION
Since `OcrdPage.get_AllRegions` has been introduced in core, we support region-region recursion (which is unavoidable for cases like drop-cap text-regions, tables or other region types with text) in most processors (including all OCR wrappers). Not using this construct effectively makes a processor go blind on these structures. (This is especially bad if you want to do multi-OCR alignment or OCR evaluation.)