### PR TITLE
🐛 Set a default value for MODEL for directly calling pytest

### DIFF
--- a/test/test_recognize.py
+++ b/test/test_recognize.py
@@ -15,7 +15,7 @@ METS_KANT = assets.url_of(
     "kant_aufklaerung_1784-page-region-line-word_glyph/data/mets.xml"
 )
 WORKSPACE_DIR = tempfile.mkdtemp(prefix="test-ocrd-calamari-")
-CHECKPOINT_DIR = os.getenv("MODEL")
+CHECKPOINT_DIR = os.getenv("MODEL", "qurator-gt4histocr-1.0")
 DEBUG = os.getenv("DEBUG", False)
 
 


### PR DESCRIPTION
The model/checkpoint directory now comes from an environment variable MODEL and while it is set in the Makefile, a bare "pytest" run does not usually have this set.

Set a default value for MODEL/CHECKPOINT_DIR.

Fixes gh-99.