### PR TITLE
🧹 Review test.base

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -1,13 +1,8 @@
 # pylint: disable=unused-import
 
-import os
-import sys
 from test.assets import assets
 
 from ocrd_utils import initLogging
-
-PWD = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(PWD + "/../ocrd")
 
 initLogging()
 

--- a/test/base.py
+++ b/test/base.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-import
-
 from test.assets import assets
 
 from ocrd_utils import initLogging


### PR DESCRIPTION
- Removes `sys.path` change
- Removes pylint pragma `unused-import` (it's better to set `__all__`)

Closes gh-98.